### PR TITLE
Add Piper TTS GUI with curated voices

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The Phantom source code is structured as follows:
 | `src/setup`      | source for Phantomsetup utility                       |
 | `src/tests`      | source for unit tests and the Phantom testsuite       |
 | `src/utils`      | source for optional utilities and analysis            |
+| `scripts/piper_tts_gui.py` | dark themed Piper text-to-speech front-end (see `docs/piper_studio.md`) |
 
 Getting help
 ------------

--- a/data/piper_voices.json
+++ b/data/piper_voices.json
@@ -1,0 +1,41 @@
+[
+  {
+    "id": "en_US-lessac-high",
+    "name": "Lessac (US English High)",
+    "description": "A clear US English female voice that balances warmth with articulation. Popular among Piper users for narration and general-purpose synthesis.",
+    "language": "English (United States)",
+    "quality": "High",
+    "speaker": null,
+    "model": "voices/en_US-lessac-high/en_US-lessac-high.onnx",
+    "config": "voices/en_US-lessac-high/en_US-lessac-high.onnx.json",
+    "download": "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US-lessac-high.onnx",
+    "download_config": "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US-lessac-high.onnx.json",
+    "sample_rate": 22050
+  },
+  {
+    "id": "en_US-libritts-high",
+    "name": "LibriTTS (US English High)",
+    "description": "A natural sounding US English voice built from LibriTTS data. Favoured for its expressive tone and intelligibility.",
+    "language": "English (United States)",
+    "quality": "High",
+    "speaker": null,
+    "model": "voices/en_US-libritts-high/en_US-libritts-high.onnx",
+    "config": "voices/en_US-libritts-high/en_US-libritts-high.onnx.json",
+    "download": "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US-libritts-high.onnx",
+    "download_config": "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US-libritts-high.onnx.json",
+    "sample_rate": 22050
+  },
+  {
+    "id": "en_GB-semaine-high",
+    "name": "SEMAINE (British English High)",
+    "description": "A polished British English voice with a calm delivery, widely recommended for clarity and storytelling.",
+    "language": "English (United Kingdom)",
+    "quality": "High",
+    "speaker": null,
+    "model": "voices/en_GB-semaine-high/en_GB-semaine-high.onnx",
+    "config": "voices/en_GB-semaine-high/en_GB-semaine-high.onnx.json",
+    "download": "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB-semaine-high.onnx",
+    "download_config": "https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB-semaine-high.onnx.json",
+    "sample_rate": 22050
+  }
+]

--- a/docs/piper_studio.md
+++ b/docs/piper_studio.md
@@ -1,0 +1,60 @@
+# Piper Studio – Piper Text-to-Speech Front-End
+
+`Piper Studio` is a small Tkinter application that ships with Phantom to make it
+easier to experiment with high quality [Piper](https://github.com/rhasspy/piper)
+voices. The interface embraces a dark, Windows 11–inspired aesthetic and keeps
+the workflow focused on the essentials: choose a curated voice, load or edit a
+script, then play the audio or export it to an MP3 file.
+
+## Features
+
+- Curated voice list containing three of the community favourites:
+  - `en_US-lessac-high` – warm, articulate US English voice.
+  - `en_US-libritts-high` – expressive US English LibriTTS voice.
+  - `en_GB-semaine-high` – calm, polished British English voice.
+- Load text from `.txt` files or type directly into the editor.
+- One-click playback (using `simpleaudio`, Windows `winsound`, or `ffplay`).
+- MP3 export via `pydub` or the `ffmpeg` command line tool.
+- Real-time status updates so you know when synthesis or conversion finishes.
+
+## Requirements
+
+1. [Piper](https://github.com/rhasspy/piper) must be installed and available on
+   your system `PATH`, or you can browse for the executable inside the app.
+2. Download the voice models listed in `data/piper_voices.json` and place them
+   under the repository `voices/` directory, preserving the folder structure.
+3. For playback and MP3 export you need one of the following optional tools:
+   - Playback: [`simpleaudio`](https://github.com/hamiltron/py-simple-audio),
+     Windows `winsound`, or `ffplay` (part of FFmpeg).
+   - MP3 export: [`pydub`](https://github.com/jiaaro/pydub) **or** the `ffmpeg`
+     command line tool.
+
+## Running the app
+
+From the root of the repository run:
+
+```bash
+python -m scripts.piper_tts_gui
+```
+
+The application remembers neither settings nor text between sessions, so the
+behaviour is predictable and side-effect free. When a voice is missing the UI
+shows download links so you can fetch the ONNX model and JSON config quickly.
+
+## Customising voices
+
+The curated voice list lives in `data/piper_voices.json`. Each entry contains the
+model and config file paths (relative to the repository root), a sample rate and
+optional download URLs. Feel free to add more entries for personal use; the GUI
+will automatically list them the next time it starts.
+
+## Troubleshooting
+
+- **Playback errors** – Install `simpleaudio` (`pip install simpleaudio`) or
+  make sure `ffplay` is on your `PATH`.
+- **MP3 export errors** – Install `pydub` plus FFmpeg, or provide the FFmpeg
+  executable directly.
+- **Voice marked as missing** – Verify the model and config files exist at the
+  paths defined in the JSON registry.
+
+Happy synthesising!

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,3 @@
+"""Utility scripts for the Phantom project."""
+
+__all__ = []

--- a/scripts/piper_tts.py
+++ b/scripts/piper_tts.py
@@ -1,0 +1,246 @@
+"""Helper utilities for interacting with Piper text-to-speech voices.
+
+The :class:`PiperTTS` helper is intentionally lightweight and works with the
+`piper` command line interface. It provides convenience wrappers that the GUI
+can use for synthesis, playback and exporting audio.
+
+The helper favours standard library dependencies so that it can be deployed in
+the same environments where Phantom is typically compiled. Optional extras such
+as ``pydub`` or ``simpleaudio`` will be used if they are available at runtime
+but are not required.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+
+@dataclass
+class PiperVoice:
+    """Metadata describing a Piper voice model."""
+
+    id: str
+    name: str
+    description: str
+    language: str
+    quality: str
+    model: str
+    config: str
+    sample_rate: int
+    download: Optional[str] = None
+    download_config: Optional[str] = None
+    speaker: Optional[str] = None
+
+    def model_path(self, base_dir: Path) -> Path:
+        return (base_dir / self.model).expanduser().resolve()
+
+    def config_path(self, base_dir: Path) -> Path:
+        return (base_dir / self.config).expanduser().resolve()
+
+    def exists(self, base_dir: Path) -> bool:
+        return self.model_path(base_dir).is_file() and self.config_path(base_dir).is_file()
+
+
+class PiperVoiceRegistry:
+    """Registry holding the voices that are available to the application."""
+
+    def __init__(self, voices: Iterable[PiperVoice]):
+        self._voices: Dict[str, PiperVoice] = {voice.id: voice for voice in voices}
+
+    def __iter__(self):
+        return iter(self._voices.values())
+
+    def __len__(self) -> int:
+        return len(self._voices)
+
+    def get(self, voice_id: str) -> PiperVoice:
+        if voice_id not in self._voices:
+            raise KeyError(f"Unknown Piper voice '{voice_id}'.")
+        return self._voices[voice_id]
+
+    @classmethod
+    def from_json(cls, path: Path) -> "PiperVoiceRegistry":
+        with open(path, "r", encoding="utf8") as handle:
+            raw = json.load(handle)
+        voices = [PiperVoice(**entry) for entry in raw]
+        return cls(voices)
+
+
+class PiperError(RuntimeError):
+    """Raised when synthesis fails."""
+
+
+class PiperTTS:
+    """Thin wrapper around the ``piper`` executable."""
+
+    def __init__(self, piper_executable: Optional[str] = None, voices: Optional[PiperVoiceRegistry] = None):
+        self.piper_executable = piper_executable or shutil.which("piper") or "piper"
+        self.voices = voices
+
+    def update_executable(self, executable: str) -> None:
+        self.piper_executable = executable
+
+    def ensure_executable(self) -> str:
+        candidate = shutil.which(self.piper_executable) if os.path.sep not in self.piper_executable else self.piper_executable
+        if candidate and Path(candidate).is_file():
+            return candidate
+        raise PiperError(
+            "Unable to locate the 'piper' executable. Please install Piper or "
+            "specify the full path to the executable in the application settings."
+        )
+
+    def synthesise_to_wav(
+        self,
+        text: str,
+        voice: PiperVoice,
+        base_dir: Path,
+        output_path: Path,
+        length_scale: Optional[float] = None,
+        speaker: Optional[int] = None,
+    ) -> Path:
+        if not text.strip():
+            raise PiperError("No text supplied for synthesis.")
+
+        if not voice.exists(base_dir):
+            raise PiperError(
+                f"Voice '{voice.name}' is not ready. Expected to find model at "
+                f"{voice.model_path(base_dir)} and config at {voice.config_path(base_dir)}."
+            )
+
+        executable = self.ensure_executable()
+
+        cmd = [
+            executable,
+            "--model",
+            str(voice.model_path(base_dir)),
+            "--config",
+            str(voice.config_path(base_dir)),
+            "--output_file",
+            str(output_path),
+        ]
+
+        if length_scale is not None:
+            cmd.extend(["--length_scale", str(length_scale)])
+
+        if speaker is not None:
+            cmd.extend(["--speaker", str(speaker)])
+        elif voice.speaker is not None:
+            cmd.extend(["--speaker", str(voice.speaker)])
+
+        process = subprocess.run(
+            cmd,
+            input=text.encode("utf8"),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+        if process.returncode != 0:
+            raise PiperError(
+                "Piper synthesis failed:\n" + process.stderr.decode("utf8", errors="ignore")
+            )
+
+        if not output_path.is_file():
+            raise PiperError("Piper synthesis finished but the output file was not created.")
+
+        return output_path
+
+    # Audio helpers -----------------------------------------------------------------
+
+    def play_audio(self, wav_path: Path) -> None:
+        """Attempt to play a WAV file using available backends."""
+
+        wav_path = wav_path.resolve()
+        if not wav_path.is_file():
+            raise PiperError(f"Audio file {wav_path} does not exist.")
+
+        # Prefer simpleaudio when available because it is lightweight and synchronous.
+        try:
+            import simpleaudio  # type: ignore
+
+            wave_obj = simpleaudio.WaveObject.from_wave_file(str(wav_path))
+            play_obj = wave_obj.play()
+            play_obj.wait_done()
+            return
+        except ImportError:
+            pass
+
+        # Fallback to winsound on Windows.
+        if sys.platform.startswith("win"):
+            try:
+                import winsound
+
+                winsound.PlaySound(str(wav_path), winsound.SND_FILENAME)
+                return
+            except Exception as exc:  # pragma: no cover - platform specific
+                raise PiperError(f"Unable to play audio using winsound: {exc}")
+
+        # Try ffplay if present in PATH.
+        ffplay = shutil.which("ffplay")
+        if ffplay:
+            process = subprocess.run([ffplay, "-nodisp", "-autoexit", str(wav_path)])
+            if process.returncode == 0:
+                return
+
+        raise PiperError(
+            "Audio playback requires either the 'simpleaudio' Python package, Windows winsound support, "
+            "or the 'ffplay' command. Please install one of these to use playback."
+        )
+
+    def convert_wav_to_mp3(self, wav_path: Path, mp3_path: Path) -> None:
+        wav_path = wav_path.resolve()
+        mp3_path = mp3_path.resolve()
+
+        if not wav_path.is_file():
+            raise PiperError(f"Expected WAV file at {wav_path}")
+
+        # Try pydub first as it gives the best experience.
+        try:
+            from pydub import AudioSegment  # type: ignore
+
+            audio = AudioSegment.from_wav(str(wav_path))
+            audio.export(str(mp3_path), format="mp3")
+            return
+        except ImportError:
+            pass
+
+        # Fallback to ffmpeg/ffprobe.
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            process = subprocess.run(
+                [ffmpeg, "-y", "-i", str(wav_path), str(mp3_path)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            if process.returncode == 0:
+                return
+            raise PiperError(
+                "ffmpeg failed to convert audio:\n" + process.stderr.decode("utf8", errors="ignore")
+            )
+
+        raise PiperError(
+            "MP3 export requires either the 'pydub' Python package (with ffmpeg installed) or the 'ffmpeg' command."
+        )
+
+
+def load_registry_from_default(data_path: Path) -> PiperVoiceRegistry:
+    """Load the bundled voice registry."""
+
+    return PiperVoiceRegistry.from_json(data_path / "piper_voices.json")
+
+
+__all__ = [
+    "PiperError",
+    "PiperTTS",
+    "PiperVoice",
+    "PiperVoiceRegistry",
+    "load_registry_from_default",
+]

--- a/scripts/piper_tts_gui.py
+++ b/scripts/piper_tts_gui.py
@@ -1,0 +1,286 @@
+"""Dark-themed Piper text-to-speech GUI inspired by Windows 11."""
+
+from __future__ import annotations
+
+import queue
+import tempfile
+import threading
+import tkinter as tk
+from pathlib import Path
+from tkinter import filedialog, messagebox, ttk
+
+from . import piper_tts
+
+
+APP_TITLE = "Piper Studio"
+WINDOW_MIN_WIDTH = 820
+WINDOW_MIN_HEIGHT = 600
+
+
+class PiperApp(tk.Tk):
+    def __init__(self, base_dir: Path):
+        super().__init__()
+        self.base_dir = base_dir
+        self.registry = piper_tts.load_registry_from_default(base_dir / "data")
+        self.tts = piper_tts.PiperTTS(voices=self.registry)
+        self._status_queue: "queue.Queue[str]" = queue.Queue()
+
+        self.title(APP_TITLE)
+        self.geometry(f"{WINDOW_MIN_WIDTH}x{WINDOW_MIN_HEIGHT}")
+        self.minsize(WINDOW_MIN_WIDTH, WINDOW_MIN_HEIGHT)
+
+        self._setup_theme()
+        self._create_widgets()
+        self.after(150, self._poll_status_queue)
+
+    # ------------------------------------------------------------------ UI setup
+
+    def _setup_theme(self) -> None:
+        self.configure(bg="#101014")
+        style = ttk.Style()
+        style.theme_use("clam")
+
+        dark_bg = "#101014"
+        panel_bg = "#1b1f29"
+        accent = "#4f8cff"
+        text_color = "#f4f5f7"
+        muted_text = "#9aa0ac"
+
+        style.configure("TFrame", background=dark_bg)
+        style.configure("Card.TFrame", background=panel_bg, relief="flat")
+        style.configure("Accent.TButton", background=accent, foreground=text_color, borderwidth=0, focusthickness=3)
+        style.map(
+            "Accent.TButton",
+            background=[("active", "#6a9dff"), ("disabled", "#243150")],
+            foreground=[("disabled", muted_text)],
+        )
+        style.configure("Secondary.TButton", background="#252a36", foreground=text_color, borderwidth=0)
+        style.map(
+            "Secondary.TButton",
+            background=[("active", "#313747")],
+            foreground=[("disabled", muted_text)],
+        )
+        style.configure("TLabel", background=dark_bg, foreground=text_color)
+        style.configure("Muted.TLabel", background=dark_bg, foreground=muted_text)
+        style.configure("Card.TLabel", background=panel_bg, foreground=text_color)
+        style.configure("TMenubutton", background=panel_bg, foreground=text_color)
+        style.configure("TCombobox", fieldbackground=panel_bg, foreground=text_color, background=panel_bg)
+        style.map("TCombobox", fieldbackground=[("readonly", panel_bg)], selectbackground=[("readonly", panel_bg)])
+        style.configure("Status.TLabel", background=panel_bg, foreground=muted_text)
+
+    def _create_widgets(self) -> None:
+        root_frame = ttk.Frame(self)
+        root_frame.pack(fill="both", expand=True, padx=24, pady=24)
+
+        header = ttk.Label(root_frame, text="Piper Studio", font=("Segoe UI Variable Display", 20, "bold"))
+        header.pack(anchor="w")
+        subtitle = ttk.Label(
+            root_frame,
+            text="Generate natural speech with curated Piper voices.",
+            style="Muted.TLabel",
+            font=("Segoe UI", 11),
+        )
+        subtitle.pack(anchor="w", pady=(2, 16))
+
+        controls = ttk.Frame(root_frame, style="Card.TFrame")
+        controls.pack(fill="x", pady=(0, 16))
+
+        # Piper executable selector
+        exe_label = ttk.Label(controls, text="Piper executable", style="Card.TLabel")
+        exe_label.grid(row=0, column=0, sticky="w", padx=18, pady=(18, 4))
+        self.exe_var = tk.StringVar(value=self.tts.piper_executable)
+        self.exe_var.trace_add("write", lambda *_: self.tts.update_executable(self.exe_var.get()))
+        exe_entry = ttk.Entry(controls, textvariable=self.exe_var, width=50)
+        exe_entry.grid(row=1, column=0, padx=18, pady=(0, 12), sticky="we")
+        browse_btn = ttk.Button(
+            controls,
+            text="Browse",
+            style="Secondary.TButton",
+            command=self._browse_executable,
+        )
+        browse_btn.grid(row=1, column=1, padx=(0, 18), pady=(0, 12))
+
+        # Voice selector
+        voice_label = ttk.Label(controls, text="Voice", style="Card.TLabel")
+        voice_label.grid(row=2, column=0, sticky="w", padx=18, pady=(4, 4))
+        self.voice_var = tk.StringVar(value=self._default_voice())
+        self.voice_combo = ttk.Combobox(
+            controls,
+            textvariable=self.voice_var,
+            state="readonly",
+            values=[voice.id for voice in self.registry],
+        )
+        self.voice_combo.grid(row=3, column=0, padx=18, pady=(0, 12), sticky="we")
+        self.voice_combo.bind("<<ComboboxSelected>>", lambda *_: self._update_voice_details())
+
+        self.voice_details = ttk.Label(controls, text="", style="Status.TLabel", justify="left", wraplength=520)
+        self.voice_details.grid(row=4, column=0, columnspan=2, padx=18, pady=(0, 18), sticky="we")
+
+        controls.columnconfigure(0, weight=1)
+
+        # Text area card
+        text_card = ttk.Frame(root_frame, style="Card.TFrame")
+        text_card.pack(fill="both", expand=True, pady=(0, 16))
+
+        text_header = ttk.Label(text_card, text="Script", style="Card.TLabel", font=("Segoe UI", 11, "bold"))
+        text_header.pack(anchor="w", padx=18, pady=(18, 6))
+
+        text_toolbar = ttk.Frame(text_card, style="Card.TFrame")
+        text_toolbar.pack(fill="x", padx=18)
+        load_btn = ttk.Button(text_toolbar, text="Load text file", style="Secondary.TButton", command=self._load_text_file)
+        load_btn.pack(side="left")
+        clear_btn = ttk.Button(text_toolbar, text="Clear", style="Secondary.TButton", command=lambda: self.text_widget.delete("1.0", "end"))
+        clear_btn.pack(side="left", padx=(8, 0))
+
+        text_container = ttk.Frame(text_card, style="Card.TFrame")
+        text_container.pack(fill="both", expand=True, padx=18, pady=(6, 18))
+        self.text_widget = tk.Text(
+            text_container,
+            wrap="word",
+            height=12,
+            bg="#151922",
+            fg="#f4f5f7",
+            insertbackground="#f4f5f7",
+            font=("Segoe UI", 11),
+            relief="flat",
+            highlightthickness=1,
+            highlightbackground="#2a3140",
+        )
+        self.text_widget.pack(fill="both", expand=True)
+
+        # Action buttons
+        action_bar = ttk.Frame(root_frame, style="Card.TFrame")
+        action_bar.pack(fill="x")
+
+        self.play_btn = ttk.Button(action_bar, text="Play", style="Accent.TButton", command=self._play_audio)
+        self.play_btn.pack(side="left", padx=18, pady=18)
+
+        self.save_btn = ttk.Button(action_bar, text="Save as MP3", style="Accent.TButton", command=self._export_mp3)
+        self.save_btn.pack(side="left")
+
+        self.status_label = ttk.Label(action_bar, text="Ready.", style="Status.TLabel")
+        self.status_label.pack(side="right", padx=18)
+
+        self._update_voice_details()
+
+    # ------------------------------------------------------------------ UI helpers
+
+    def _default_voice(self) -> str:
+        voices = list(self.registry)
+        return voices[0].id if voices else ""
+
+    def _update_voice_details(self) -> None:
+        try:
+            voice = self.registry.get(self.voice_var.get())
+        except KeyError:
+            self.voice_details.config(text="")
+            return
+
+        exists = voice.exists(self.base_dir)
+        status = "Available" if exists else "Missing files"
+        hint = "" if exists else f"\nDownload: {voice.download}\nConfig: {voice.download_config}"
+        description = (
+            f"{voice.name}\n"
+            f"Language: {voice.language} • Quality: {voice.quality}\n"
+            f"Status: {status}{hint}"
+        )
+        self.voice_details.config(text=description)
+
+    def _browse_executable(self) -> None:
+        filename = filedialog.askopenfilename(title="Select Piper executable")
+        if filename:
+            self.exe_var.set(filename)
+            self.tts.update_executable(filename)
+            self._set_status("Updated Piper executable path.")
+
+    def _load_text_file(self) -> None:
+        filename = filedialog.askopenfilename(filetypes=[("Text files", "*.txt"), ("All files", "*.*")])
+        if not filename:
+            return
+        try:
+            with open(filename, "r", encoding="utf8") as handle:
+                content = handle.read()
+        except OSError as exc:
+            messagebox.showerror(APP_TITLE, f"Failed to read file:\n{exc}")
+            return
+        self.text_widget.delete("1.0", "end")
+        self.text_widget.insert("1.0", content)
+        self._set_status(f"Loaded text from {filename}.")
+
+    # ------------------------------------------------------------------ Actions
+
+    def _play_audio(self) -> None:
+        self._launch_worker(self._play_worker)
+
+    def _export_mp3(self) -> None:
+        filename = filedialog.asksaveasfilename(defaultextension=".mp3", filetypes=[("MP3", "*.mp3")])
+        if not filename:
+            return
+        self._launch_worker(lambda: self._export_worker(Path(filename)))
+
+    # ------------------------------------------------------------------ Workers
+
+    def _launch_worker(self, task):
+        thread = threading.Thread(target=self._safe_execute, args=(task,), daemon=True)
+        thread.start()
+
+    def _safe_execute(self, task):
+        self._set_status("Processing…")
+        self._toggle_buttons(False)
+        try:
+            task()
+            self._set_status("Completed.")
+        except piper_tts.PiperError as exc:
+            self._set_status("Error")
+            messagebox.showerror(APP_TITLE, str(exc))
+        except Exception as exc:  # pragma: no cover - defensive programming
+            self._set_status("Error")
+            messagebox.showerror(APP_TITLE, f"Unexpected error: {exc}")
+        finally:
+            self._toggle_buttons(True)
+
+    def _play_worker(self):
+        voice = self.registry.get(self.voice_var.get())
+        text = self.text_widget.get("1.0", "end")
+        with tempfile.TemporaryDirectory(prefix="piper-studio-") as tmpdir:
+            wav_path = Path(tmpdir) / "preview.wav"
+            self.tts.synthesise_to_wav(text, voice, self.base_dir, wav_path)
+            self.tts.play_audio(wav_path)
+
+    def _export_worker(self, mp3_path: Path):
+        voice = self.registry.get(self.voice_var.get())
+        text = self.text_widget.get("1.0", "end")
+        with tempfile.TemporaryDirectory(prefix="piper-studio-") as tmpdir:
+            wav_path = Path(tmpdir) / "export.wav"
+            self.tts.synthesise_to_wav(text, voice, self.base_dir, wav_path)
+            self.tts.convert_wav_to_mp3(wav_path, mp3_path)
+
+    # ------------------------------------------------------------------ Utilities
+
+    def _toggle_buttons(self, state: bool) -> None:
+        new_state = "!disabled" if state else "disabled"
+        for widget in (self.play_btn, self.save_btn):
+            widget.state([new_state])
+
+    def _set_status(self, message: str) -> None:
+        self._status_queue.put(message)
+
+    def _poll_status_queue(self) -> None:
+        try:
+            while True:
+                message = self._status_queue.get_nowait()
+                self.status_label.config(text=message)
+        except queue.Empty:
+            pass
+        finally:
+            self.after(150, self._poll_status_queue)
+
+
+def main() -> None:
+    base_dir = Path(__file__).resolve().parents[1]
+    app = PiperApp(base_dir)
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a curated Piper voice registry and documentation for the new GUI
- implement a Windows 11-inspired dark mode Tkinter front-end for playing and exporting Piper speech
- introduce helper utilities for invoking Piper, handling playback, and exporting MP3 audio

## Testing
- python -m compileall scripts/piper_tts.py scripts/piper_tts_gui.py

------
https://chatgpt.com/codex/tasks/task_e_68e1ea0ce934832cb6eb2c9b5f1b4089